### PR TITLE
Update Python and Poetry to fix commit errors

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: "3.9"
+        PYTHON_VERSION: ["3.9"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         PYTHON_VERSION: ["3.6"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v2
 
     - name: Set up Python ${{matrix.PYTHON_VERSION}}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{matrix.PYTHON_VERSION}}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.6.7"]
+        PYTHON_VERSION: ["3.6.15"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,7 +2,7 @@ name: Python package
 
 on: [push]
 env:
-  POETRY_VERSION: 1.1
+  POETRY_VERSION: 1.1.15
 
 jobs:
   testing:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{matrix.PYTHON_VERSION}}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.PYTHON_VERSION}}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.6", "3.7", "3.9"]
+        PYTHON_VERSION: ["3.7.15", "3.9.16"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.6"]
+        PYTHON_VERSION: ["3.6", "3.7", "3.8", "3.9"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.6.15"]
+        PYTHON_VERSION: ["3.6"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{matrix.PYTHON_VERSION}}
       uses: actions/setup-python@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{matrix.PYTHON_VERSION}}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{matrix.PYTHON_VERSION}}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,14 +2,14 @@ name: Python package
 
 on: [push]
 env:
-  POETRY_VERSION: 1.1
+  POETRY_VERSION: 1.1.15
 
 jobs:
   testing:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.6.15"]
+        PYTHON_VERSION: ["3.9.16"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,14 +2,14 @@ name: Python package
 
 on: [push]
 env:
-  POETRY_VERSION: 1.1.15
+  POETRY_VERSION: 1.1
 
 jobs:
   testing:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.6"]
+        PYTHON_VERSION: ["3.7"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.9"]
+        PYTHON_VERSION: ["3.6", "3.7", "3.9"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.10.9"]
+        PYTHON_VERSION: ["3.6.15"]
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{matrix.PYTHON_VERSION}}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v1
       with:
         python-version: ${{matrix.PYTHON_VERSION}}
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.6.15"]
+        PYTHON_VERSION: ["3.6"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.7"]
+        PYTHON_VERSION: ["3.6.7"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ env:
 
 jobs:
   testing:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         PYTHON_VERSION: ["3.6"]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.6", "3.7"]
+        PYTHON_VERSION: 3.9
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.9.16"]
+        PYTHON_VERSION: ["3.6.15"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: 3.9
+        PYTHON_VERSION: "3.9"
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.7.15", "3.9.16"]
+        PYTHON_VERSION: ["3.10.8"]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PYTHON_VERSION: ["3.10.8"]
+        PYTHON_VERSION: ["3.10.9"]
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ conda activate pybedlite
 poetry install
 ```
 
+If the methods listed above do not work try the following:
+```bash
+mamba create -n pybedlite -c conda-forge "python=3.9.16" "poetry=1.1.15"
+mamba activate pybedlite
+poetry install
+```
+
 If, during `poetry install` on Mac OS X errors are encountered running gcc/clang to build `pybedtools` or other packages with native code, try setting the following and re-running `poetry install`:
 ```bash
 export CFLAGS="-stdlib=libc++"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+#TEST for commit failure
 [![Language][language-badge]][language-link]
 [![Code Style][code-style-badge]][code-style-link]
 [![Type Checked][type-checking-badge]][type-checking-link]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#TEST for commit failure
+
 [![Language][language-badge]][language-link]
 [![Code Style][code-style-badge]][code-style-link]
 [![Type Checked][type-checking-badge]][type-checking-link]


### PR DESCRIPTION
1. Updated Python from 3.6 / 3.7 ->  3.9.16
2. Updated Poetry 1.1 -> 1.1.15
3. Added instructions in README for mamba install in the case of the OSError shown below which was thrown when using conda. 

`OSError
Could not find a suitable TLS CA certificate bundle, invalid path: /Users/---/mambaforge/envs/pybedlite/lib/python3.9/site-packages/certifi/cacert.pem`