### PR TITLE
Configure RTD to checkout submodules

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,12 @@
 build:
-    image: latest
+  image: latest
 version: 2
+submodules:
+  include: all
 sphinx:
   configuration: docs/conf.py
 python:
-    version: 3.6
-    install:
+  install:
     - method: pip
       path: .
       extra_requirements:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,7 @@
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
 version: 2
 submodules:
   include: all

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@
 See documentation on [pybedlite.readthedocs.org][rtd-link].
 
 ```
+pip install pybedlite
+```
+OR
+```
 conda install -c bioconda pybedlite
 ```
 OR
@@ -46,18 +50,18 @@ conda create -n pybedlite pybedlite
 conda activate pybedlite
 ```
 
-Note that while there is a version of pybedlite on pypi versions of pybedlite >=
-0.0.2 cannot at present be installed via pypi because they have dependencies
-that preclude publishing to pypi. For this reason installation via conda is
-required.
-
 [rtd-link]:    http://pybedlite.readthedocs.org/en/stable
 
 **Requires python 3.8+** (for python < 3.8, please use pybedlite <= 0.0.3)
 
 # Getting Setup for Development Work
 
-[Poetry][poetry-link] is used to manage the python development environment. 
+Clone the repository to your local machine. Note that pybedlite >= 0.0.4 includes [cgranges][cgranges-link] as a submodule, so you must use the `--recurse-submodules` option:
+```
+git clone --recurse-submodules https://github.com/fulcrumgenomics/pybedlite.git
+```
+
+[Poetry][poetry-link] is used to manage the python development environment.
 
 A simple way to create an environment with the desired version of python and poetry is to use [conda][conda-link].  E.g.:
 
@@ -81,6 +85,7 @@ export CFLAGS="-stdlib=libc++"
 
 [poetry-link]: https://github.com/python-poetry/poetry
 [conda-link]:  https://docs.conda.io/en/latest/miniconda.html
+[cgranges-link]: https://github.com/lh3/cgranges
 
 ## Checking the Build
 ### Run all checks with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.intersphinx',
               'sphinx.ext.napoleon']
 
-intersphinx_mapping = {'python': ('http://docs.python.org/3.6', None)}
+intersphinx_mapping = {'python': ('http://docs.python.org/3.8', None)}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,7 +2,7 @@
 Installation
 ============
 
-**Requires python 3.6+**
+**Requires python 3.8+**
 
 Install with::
 
@@ -17,7 +17,7 @@ Getting Setup
 A simple way to create an environment with the desired version of python and poetry is to use `conda <https://docs.conda.io/en/latest/miniconda.html>`_.
 E.g.::
 
-    conda create -n pybedlite python=3.6 poetry
+    conda create -n pybedlite python=3.8 poetry
     conda activate pybedlite
     poetry install
 


### PR DESCRIPTION
Our RTD config was out of date. I made the following updates:

* Change from `build.image: latest` to `bulid.os: ubuntu-22.04`
* Add `build.tools`
* Add `submodules.include: all`

Confirmed that the updates work: https://readthedocs.org/projects/pybedlite/builds/21890877/

In addition, I updated the docs to specify python 3.8 as the minimum supported version, and removed the note about not being able to publish to pypi.