### PR TITLE
Add GHA workflow to build wheels for multiple platforms

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build wheels for multiple platforms
 
 on:
   push:
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-2019, macOS-11]
         PYTHON_VERSION: ["3.8", "3.9", "3.10", "3.11"]
-    
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,6 +3,7 @@ name: Build wheels for multiple platforms
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macOS-11]
+        PYTHON_VERSION: ["3.8", "3.9", "3.10", "3.11"]
+    
+    steps:
+      - uses: actions/checkout@v4
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v3
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.15.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,9 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "true"
 
       # Used to host cibuildwheel
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0


### PR DESCRIPTION
Add a workflow that uses [cibuildwheel](https://cibuildwheel.readthedocs.io/en/stable/) to build wheels for linux, mac, and windows and for all supported python versions.

Unfortunately, it is only possible to trigger workflows that exist in the main branch, so I can't test this before merging it.

