### PR TITLE
Fix GHA workflow for multi-platform builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: ["cp38-* cp-39* cp-310* cp-311*"]
+        python: ["cp38-* cp39-* cp310-* cp311-*"]
         include:
           - os: ubuntu-latest
             cibw_archs: "x86_64 aarch64"
@@ -36,6 +36,7 @@ jobs:
         env:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: ${{ matrix.python }}
+          CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels for ${{ matrix.python }}-${{ matrix.target }}-${{ matrix.arch }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheels for ${{ matrix.python }}-${{ matrix.platform.target }}_${{ matrix.platform.arch }} on ${{ matrix.platform.os }}
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
-        python: ["cp38", "cp39", "cp310", "cp311"]
-        include:
+        python: [cp38, cp39, cp310, cp311]
+        platform:
           - os: ubuntu-latest
             target: manylinux
             arch: x86_64
@@ -30,7 +30,7 @@ jobs:
             arch: x86_64
           - os: macos-latest
             target: macosx
-            cibw_archs: arm64
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -48,10 +48,12 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.target }}_${{ matrix.arch }}
+          CIBW_ARCHS: ${{ matrix.platform.arch }}
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform.target }}_${{ matrix.platform.arch }}
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v3
         with:
+          name: wheels
           path: ./wheelhouse/*.whl
+          if-no-files-found: error

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,16 +7,16 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels for ${{ matrix.os }}-${{ matrix.python }}
+    name: Build wheels for ${{ matrix.cibw_build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: ["cp38-* cp39-* cp310-* cp311-*"]
-        include:
-          - os: ubuntu-latest
-            cibw_archs: "x86_64 aarch64"
-          - os: macos-latest
-            cibw_archs: "x86_64 arm64"
+        cibw_build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
+        #include:
+        #  - os: ubuntu-latest
+        #    cibw_archs: "x86_64 aarch64"
+        #  - os: macos-latest
+        #    cibw_archs: "x86_64 arm64"
 
     steps:
       - uses: actions/checkout@v4
@@ -34,8 +34,9 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_BUILD: ${{ matrix.python }}
+          #CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_SKIP: "*ppc64le *s390x *i686 *win32"
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,47 +7,30 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels for ${{ matrix.cibw_build }}
+    name: Build wheels for ${{ matrix.python }}-${{ matrix.target }}-${{ matrix.arch }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        python: ["cp38", "cp39", "cp310", "cp311"]
         include:
           - os: ubuntu-latest
-            cibw_archs: x86_64
-            cibw_build:
-              - cp38-manylinux_x86_64
-              - cp38-musllinux_x86_64
-              - cp39-manylinux_x86_64
-              - cp39-musllinux_x86_64
-              - cp310-manylinux_x86_64
-              - cp310-musllinux_x86_64
-              - cp311-manylinux_x86_64
-              - cp311-musllinux_x86_64
+            target: manylinux
+            arch: x86_64
           - os: ubuntu-latest
-            cibw_archs: aarch64
-            cibw_build:
-              - cp38-manylinux_aarch64
-              - cp38-musllinux_aarch64
-              - cp39-manylinux_aarch64
-              - cp39-musllinux_aarch64
-              - cp310-manylinux_aarch64
-              - cp310-musllinux_aarch64
-              - cp311-manylinux_aarch64
-              - cp311-musllinux_aarch64
+            target: musllinux
+            arch: x86_64
+          - os: ubuntu-latest
+            target: manylinux
+            arch: aarch64
+          - os: ubuntu-latest
+            target: musllinux
+            arch: aarch64
           - os: macos-latest
-            cibw_archs: x86_64
-            cibw_build:
-              - cp38-macosx_x86_64
-              - cp39-macosx_x86_64
-              - cp310-macosx_x86_64
-              - cp311-macosx_x86_64
+            target: macosx
+            arch: x86_64
           - os: macos-latest
+            target: macosx
             cibw_archs: arm64
-            cibw_build:
-              - cp38-macosx_arm64
-              - cp39-macosx_arm64
-              - cp310-macosx_arm64
-              - cp311-macosx_arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -65,8 +48,8 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.target }}_${{ matrix.arch }}
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,12 +11,43 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cibw_build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
-        #include:
-        #  - os: ubuntu-latest
-        #    cibw_archs: "x86_64 aarch64"
-        #  - os: macos-latest
-        #    cibw_archs: "x86_64 arm64"
+        include:
+          - os: ubuntu-latest
+            cibw_archs: x86_64
+            cibw_build:
+              - cp38-manylinux_x86_64
+              - cp38-musllinux_x86_64
+              - cp39-manylinux_x86_64
+              - cp39-musllinux_x86_64
+              - cp310-manylinux_x86_64
+              - cp310-musllinux_x86_64
+              - cp311-manylinux_x86_64
+              - cp311-musllinux_x86_64
+          - os: ubuntu-latest
+            cibw_archs: aarch64
+            cibw_build:
+              - cp38-manylinux_aarch64
+              - cp38-musllinux_aarch64
+              - cp39-manylinux_aarch64
+              - cp39-musllinux_aarch64
+              - cp310-manylinux_aarch64
+              - cp310-musllinux_aarch64
+              - cp311-manylinux_aarch64
+              - cp311-musllinux_aarch64
+          - os: macos-latest
+            cibw_archs: x86_64
+            cibw_build:
+              - cp38-macosx_x86_64
+              - cp39-macosx_x86_64
+              - cp310-macosx_x86_64
+              - cp311-macosx_x86_64
+          - os: macos-latest
+            cibw_archs: arm64
+            cibw_build:
+              - cp38-macosx_arm64
+              - cp39-macosx_arm64
+              - cp310-macosx_arm64
+              - cp311-macosx_arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -34,9 +65,8 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          #CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_BUILD: ${{ matrix.cibw_build }}
-          CIBW_SKIP: "*ppc64le *s390x *i686 *win32"
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,12 +7,16 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels for ${{ matrix.os }}-${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
-        PYTHON_VERSION: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["cp38-* cp-39* cp-310* cp-311*"]
+        include:
+          - os: ubuntu-latest
+            cibw_archs: "x86_64 aarch64"
+          - os: macos-latest
+            cibw_archs: "x86_64 arm64"
 
     steps:
       - uses: actions/checkout@v4
@@ -21,15 +25,17 @@ jobs:
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.15.0
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_BUILD: ${{ matrix.python }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,12 +19,15 @@ jobs:
           - os: ubuntu-latest
             target: musllinux
             arch: x86_64
-          - os: ubuntu-latest
-            target: manylinux
-            arch: aarch64
-          - os: ubuntu-latest
-            target: musllinux
-            arch: aarch64
+          # These don't work right now - they just hang while pulling the build image from quay.
+          # If this doesn't resolve itself, we could try to configure different images:
+          # https://cibuildwheel.readthedocs.io/en/stable/options/.
+          #- os: ubuntu-latest
+          #  target: manylinux
+          #  arch: aarch64
+          #- os: ubuntu-latest
+          #  target: musllinux
+          #  arch: aarch64
           - os: macos-latest
             target: macosx
             arch: x86_64


### PR DESCRIPTION
The original commit of this workflow didn't work. I've updated it with the correct configuration. It now succeeds:
https://github.com/fulcrumgenomics/pybedlite/actions/runs/6162641801

The only remaining issue is how to tie this into the publishing process. The result of this workflow is an archive of all the wheels attached to the build, so it will require the person doing the release to download the archive, unpack it and either 1) move all the wheels into the `dist` folder and hope that poetry will just upload everything there that has the correct version, or b) manually upload the wheels to the release on pypi after publishing.

It would also be possible to automate the entire release process (e.g. using https://github.com/marketplace/actions/pypi-publish).

Side note - it looks like aarch64 linux nodes are in short supply - those build jobs take a long time.