### PR TITLE
Allow the OverlapDetector to be generic over input feature types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # VSCode configurations
 .vscode/
+
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "cgranges"]
 	path = cgranges
 	url = https://github.com/lh3/cgranges
+	ignore = dirty

--- a/pybedlite/bed_record.py
+++ b/pybedlite/bed_record.py
@@ -27,7 +27,6 @@ import attr
 if TYPE_CHECKING:
     from pybedlite.overlap_detector import Interval
 
-
 """Maximum BED fields that can be present in a well formed BED file written to specification"""
 MAX_BED_FIELDS: int = 12
 
@@ -182,6 +181,16 @@ class BedRecord:
                 else ",".join([f"{x}" for x in self.block_starts])
             ),
         ]
+
+    @property
+    def refname(self) -> str:
+        """A reference sequence name."""
+        return self.chrom
+
+    @property
+    def negative(self) -> bool:
+        """True if the interval is on the negative strand, False otherwise"""
+        return self.strand is BedStrand.Negative
 
     def as_bed_line(self, number_of_output_fields: Optional[int] = None) -> str:
         """

--- a/pybedlite/bed_record.py
+++ b/pybedlite/bed_record.py
@@ -189,7 +189,10 @@ class BedRecord:
 
     @property
     def negative(self) -> bool:
-        """True if the interval is on the negative strand, False otherwise"""
+        """
+        True if the interval is negatively stranded, False if the interval is unstranded or
+        positively stranded.
+        """
         return self.strand is BedStrand.Negative
 
     def as_bed_line(self, number_of_output_fields: Optional[int] = None) -> str:

--- a/pybedlite/bed_record.py
+++ b/pybedlite/bed_record.py
@@ -184,7 +184,7 @@ class BedRecord:
 
     @property
     def refname(self) -> str:
-        """A reference sequence name."""
+        """The reference name of the interval described by the record."""
         return self.chrom
 
     @property

--- a/pybedlite/overlap_detector.py
+++ b/pybedlite/overlap_detector.py
@@ -398,7 +398,7 @@ class OverlapDetector(Generic[GenericGenomicSpan], Iterable[GenericGenomicSpan])
         return [i for i in results if i.start >= interval.start and i.end <= interval.end]
 
     @classmethod
-    def from_bed(cls, path: Path) -> "OverlapDetector":
+    def from_bed(cls, path: Path) -> "OverlapDetector[BedRecord]":
         """Builds a :class:`~pybedlite.overlap_detector.OverlapDetector` from a BED file.
         Args:
             path: the path to the BED file

--- a/pybedlite/overlap_detector.py
+++ b/pybedlite/overlap_detector.py
@@ -80,10 +80,9 @@ from pybedlite.bed_record import BedStrand
 from pybedlite.bed_source import BedSource
 
 
-class GenomicSpan(Protocol):
+class GenomicSpan(Hashable, Protocol):
     """
-    A genomic span which has protected methods that must be implemented by all subclasses to give
-    a zero-based open-ended genomic span.
+    A structural type for a span on a reference sequence with zero-based open-ended coordinates.
     """
 
     @property
@@ -100,6 +99,11 @@ class GenomicSpan(Protocol):
 
 
 class StrandedGenomicSpan(GenomicSpan, Protocol):
+    """
+    A structural type for a stranded span on a reference sequence with zero-based open-ended
+    coordinates.
+    """
+
     @property
     def negative(self) -> bool:
         """True if the interval is on the negative strand, False otherwise"""
@@ -177,8 +181,8 @@ class Interval:
 
 GenericGenomicSpan = TypeVar("GenericGenomicSpan", bound=Union[GenomicSpan, StrandedGenomicSpan])
 """
-A generic genomic feature. This type variable is used for describing the
-generic type contained within the :class:`~pybedlite.overlap_detector.OverlapDetector`.
+A generic genomic span. This type variable is used for describing the generic type contained within
+the :class:`~pybedlite.overlap_detector.OverlapDetector`.
 """
 
 
@@ -187,16 +191,16 @@ class OverlapDetector(Generic[GenericGenomicSpan], Iterable[GenericGenomicSpan])
 
     The overlap detector may contain any interval-like Python objects that have the following
     properties:
-      * `chrom` or `contig` or `refname`: The reference sequence name
+
+      * `refname`: The reference sequence name
       * `start`: A 0-based start position
       * `end`: A 0-based exclusive end position
 
     Interval-like Python objects may also contain strandedness information which will be used
     for sorting them in :func:`~pybedlite.overlap_detector.OverlapDetector.get_overlaps` using
-    either of the following properties if they are present:
+    the following property if it is present:
+
       * `negative (bool)`: Whether or not the feature is negative stranded or not
-      * `strand (BedStrand)`: The BED strand of the feature
-      * `strand (str)`: The strand of the feature (`"-"` for negative)
 
     The same interval may be added multiple times, but only a single instance will be returned
     when querying for overlaps.

--- a/pybedlite/overlap_detector.py
+++ b/pybedlite/overlap_detector.py
@@ -346,10 +346,10 @@ class OverlapDetector(Generic[SpanType], Iterable[SpanType]):
             list if no overlaps exist. The intervals will be returned sorted using the following
             sort keys:
 
-                * The interval's start
-                * The interval's end
-                * The interval's strand (if defined)
-                * The interval's reference sequence name
+                * The interval's start (ascending)
+                * The interval's end (ascending)
+                * The interval's strand, positive or negative (assumed to be positive if undefined)
+                * The interval's reference sequence name (lexicographically)
         """
         tree = self._refname_to_tree.get(interval.refname)
         if tree is None:
@@ -392,10 +392,10 @@ class OverlapDetector(Generic[SpanType], Iterable[SpanType]):
             The list of intervals in this detector that enclose the query interval. The intervals
             will be returned sorted using the following sort keys:
 
-                * The interval's start
-                * The interval's end
-                * The interval's strand (if defined)
-                * The interval's reference sequence name
+                * The interval's start (ascending)
+                * The interval's end (ascending)
+                * The interval's strand, positive or negative (assumed to be positive if undefined)
+                * The interval's reference sequence name (lexicographically)
         """
         results = self.get_overlaps(interval)
         return [i for i in results if interval.start >= i.start and interval.end <= i.end]
@@ -411,10 +411,10 @@ class OverlapDetector(Generic[SpanType], Iterable[SpanType]):
             The list of intervals in this detector that are enclosed within the query interval.
             The intervals will be returned sorted using the following sort keys:
 
-                * The interval's start
-                * The interval's end
-                * The interval's strand (if defined)
-                * The interval's reference sequence name
+                * The interval's start (ascending)
+                * The interval's end (ascending)
+                * The interval's strand, positive or negative (assumed to be positive if undefined)
+                * The interval's reference sequence name (lexicographically)
         """
         results = self.get_overlaps(interval)
         return [i for i in results if i.start >= interval.start and i.end <= interval.end]

--- a/pybedlite/overlap_detector.py
+++ b/pybedlite/overlap_detector.py
@@ -8,7 +8,7 @@ of interval-like Python objects that have the following properties:
 
   * `refname` (str): The reference sequence name
   * `start` (int): A 0-based start position
-  * `end` (int): A 0-based exclusive end position
+  * `end` (int): A 0-based half-open end position
 
 This contract is described by the :class:`~pybedlite.overlap_detector.Span` protocol.
 
@@ -95,7 +95,7 @@ class Span(Hashable, Protocol):
 
     @property
     def end(self) -> int:
-        """A 0-based open-ended position."""
+        """A 0-based open-ended end position."""
 
 
 class StrandedSpan(Span, Protocol):
@@ -119,7 +119,7 @@ class Interval:
     Attributes:
         refname (str): the refname (or chromosome)
         start (int): the 0-based start position
-        end (int): the 0-based end position (exclusive)
+        end (int): the 0-based half-open end position
         negative (bool): true if the interval is negatively stranded, False if the interval is
             unstranded or positively stranded
         name (Optional[str]): an optional name assigned to the interval
@@ -247,19 +247,19 @@ contained within the :class:`~pybedlite.overlap_detector.OverlapDetector`.
 class OverlapDetector(Generic[SpanType], Iterable[SpanType]):
     """Detects and returns overlaps between a set of regions and another region on a reference.
 
-    The overlap detector may contain any interval-like Python objects that have the following
-    properties:
+    The overlap detector may contain a collection of interval-like Python objects that have the
+    following properties:
 
-      * `refname`: The reference sequence name
-      * `start`: A 0-based start position
-      * `end`: A 0-based exclusive end position
+        * `refname` (str): The reference sequence name
+        * `start` (int): A 0-based start position
+        * `end` (int): A 0-based half-open end position
 
     Interval-like Python objects may also contain strandedness information which will be used
-    for sorting the return of :func:`~pybedlite.overlap_detector.OverlapDetector.get_overlaps`. This
-    additional sort key will only be used if the following property on the interval-like object is
-    present:
+    for sorting them in :func:`~pybedlite.overlap_detector.OverlapDetector.get_overlaps` using
+    the following property if it is present:
 
-      * `negative (bool)`: Whether or not the feature is negative stranded or not
+        * `negative (bool)`: True if the interval is negatively stranded, False if the interval is
+            unstranded or positively stranded
 
     The same interval may be added multiple times, but only a single instance will be returned
     when querying for overlaps.

--- a/pybedlite/overlap_detector.py
+++ b/pybedlite/overlap_detector.py
@@ -17,7 +17,7 @@ Interval-like Python objects may also contain strandedness information which wil
 for sorting them in :func:`~pybedlite.overlap_detector.OverlapDetector.get_overlaps` using
 the following property if it is present, otherwise assumed to be positive stranded:
 
-  * `negative (bool)`: True if the span is negatively stranded, False if the interval is
+  * `negative (bool)`: True if the interval is negatively stranded, False if the interval is
     unstranded or positively stranded
 
 This is encapsulated in the :class:`~pybedlite.overlap_detector.StrandedGenomicSpan` protocol.
@@ -108,7 +108,7 @@ class StrandedGenomicSpan(GenomicSpan, Protocol):
     @property
     def negative(self) -> bool:
         """
-        True if the span is negatively stranded, False if the interval is unstranded or
+        True if the interval is negatively stranded, False if the interval is unstranded or
         positively stranded.
         """
 
@@ -121,7 +121,7 @@ class Interval:
         refname (str): the refname (or chromosome)
         start (int): the 0-based start position
         end (int): the 0-based end position (exclusive)
-        negative (bool): true if the span is negatively stranded, False if the interval is
+        negative (bool): true if the interval is negatively stranded, False if the interval is
             unstranded or positively stranded
         name (Optional[str]): an optional name assigned to the interval
     """
@@ -380,8 +380,8 @@ class OverlapDetector(Generic[GenericGenomicSpan], Iterable[GenericGenomicSpan])
     @staticmethod
     def _negative(interval: GenomicSpan) -> bool:
         """
-        True if the span is negatively stranded, False if the interval is unstranded or positively
-        stranded.
+        True if the interval is negatively stranded, False if the interval is unstranded or
+        positively stranded.
         """
         return getattr(interval, "negative", False)
 

--- a/pybedlite/overlap_detector.py
+++ b/pybedlite/overlap_detector.py
@@ -2,25 +2,24 @@
 Utility Classes for Querying Overlaps with Genomic Regions
 ----------------------------------------------------------
 
-
 The :class:`~pybedlite.overlap_detector.OverlapDetector` class detects and returns overlaps between
-a set of regions and another region on a reference. The overlap detector may contain any
-interval-like Python objects that have the following properties:
+a set of regions and another region on a reference. The overlap detector may contain a collection
+of interval-like Python objects that have the following properties:
 
   * `refname` (str): The reference sequence name
   * `start` (int): A 0-based start position
   * `end` (int): A 0-based exclusive end position
 
-This is encapsulated in the :class:`~pybedlite.overlap_detector.Span` protocol.
+This contract is described by the :class:`~pybedlite.overlap_detector.Span` protocol.
 
 Interval-like Python objects may also contain strandedness information which will be used
 for sorting them in :func:`~pybedlite.overlap_detector.OverlapDetector.get_overlaps` using
-the following property if it is present, otherwise assumed to be positive stranded:
+the following property if it is present:
 
   * `negative (bool)`: True if the interval is negatively stranded, False if the interval is
     unstranded or positively stranded
 
-This is encapsulated in the :class:`~pybedlite.overlap_detector.StrandedSpan` protocol.
+This contract is described by the :class:`~pybedlite.overlap_detector.StrandedSpan` protocol.
 
 Examples of Detecting Overlaps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pybedlite/overlap_detector.py
+++ b/pybedlite/overlap_detector.py
@@ -24,7 +24,7 @@ This is encapsulated in the :class:`~pybedlite.overlap_detector.StrandedGenomicS
 Examples of Detecting Overlaps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-. code-block:: python
+.. code-block:: python
 
     >>> from pybedlite.overlap_detector import Interval, OverlapDetector
     >>> detector = OverlapDetector()

--- a/pybedlite/tests/test_overlap_detector.py
+++ b/pybedlite/tests/test_overlap_detector.py
@@ -358,5 +358,7 @@ def test_the_overlap_detector_wont_accept_a_non_hashable_feature() -> None:
             """True if the interval is on the negative strand, False otherwise"""
             return False
 
-    with pytest.raises(ValueError):
-        OverlapDetector([ChromFeature(refname="chr1", zero_based_start=0, end=30)])
+    with pytest.raises(TypeError):
+        OverlapDetector([ChromFeature(refname="chr1", zero_based_start=0, end=30)]).get_overlaps(
+            Interval("chr1", 0, 30)
+        )

--- a/pybedlite/tests/test_overlap_detector.py
+++ b/pybedlite/tests/test_overlap_detector.py
@@ -224,6 +224,16 @@ def test_construction_from_ucsc_other_contigs(contig: str) -> None:
     assert Interval.from_ucsc(f"{contig}:101-200") == Interval(contig, 100, 200)
 
 
+def test_that_overlap_detector_allows_generic_parameterization() -> None:
+    """
+    Test that the overlap detector allows for generic parameterization.
+    """
+    records = [BedRecord(chrom="chr1", start=1, end=2), BedRecord(chrom="chr1", start=4, end=5)]
+    detector: OverlapDetector[BedRecord] = OverlapDetector(records)
+    overlaps: List[BedRecord] = detector.get_overlaps(Interval("chr1", 1, 2))
+    assert overlaps == [BedRecord(chrom="chr1", start=1, end=2)]
+
+
 def test_arbitrary_interval_types() -> None:
     """
     Test that an overlap detector can receive different interval-like objects and query them too.

--- a/pybedlite/tests/test_pybedlite.py
+++ b/pybedlite/tests/test_pybedlite.py
@@ -213,12 +213,14 @@ def test_bedstrand_opposite() -> None:
     assert BedStrand.Positive.opposite is BedStrand.Negative
     assert BedStrand.Negative.opposite is BedStrand.Positive
 
+
 def test_bedrecord_refname() -> None:
     """Test that the alternate property for reference sequence name is correct."""
-    assert BedRecord("chr1", 1, 2).refname == "chr1"
+    assert BedRecord(chrom="chr1", start=1, end=2).refname == "chr1"
+
 
 def test_bedrecord_negative() -> None:
     """Test that the negative property is set correctly."""
-    assert not BedRecord("chr1", 1, 2, strand=None).negative
-    assert not BedRecord("chr1", 1, 2, strand=BedStrand.Positive).negative
-    assert BedRecord("chr1", 1, 2, strand=BedStrand.Negative).negative
+    assert not BedRecord(chrom="chr1", start=1, end=2, strand=None).negative
+    assert not BedRecord(chrom="chr1", start=1, end=2, strand=BedStrand.Positive).negative
+    assert BedRecord(chrom="chr1", start=1, end=2, strand=BedStrand.Negative).negative

--- a/pybedlite/tests/test_pybedlite.py
+++ b/pybedlite/tests/test_pybedlite.py
@@ -212,3 +212,13 @@ def test_bedstrand_opposite() -> None:
 
     assert BedStrand.Positive.opposite is BedStrand.Negative
     assert BedStrand.Negative.opposite is BedStrand.Positive
+
+def test_bedrecord_refname() -> None:
+    """Test that the alternate property for reference sequence name is correct."""
+    assert BedRecord("chr1", 1, 2).refname == "chr1"
+
+def test_bedrecord_negative() -> None:
+    """Test that the negative property is set correctly."""
+    assert not BedRecord("chr1", 1, 2, strand=None).negative
+    assert not BedRecord("chr1", 1, 2, strand=BedStrand.Positive).negative
+    assert BedRecord("chr1", 1, 2, strand=BedStrand.Negative).negative


### PR DESCRIPTION
I'm interested in seeing what others think given that the OverlapDetector isn't an ergonomic utility to use, especially for custom interval-types which I may often choose to implement myself, or have received from a third-party package/API.

## Goals

1. The ergonomics of the OverlapDetector could be improved to store and query **_generic_** intervals.
2. This PR should introduce the fewest backwards incompatibilities

## Example with Existing API

The following demonstrates using a custom interval type with the OverlapDetector:

```python
@dataclass(eq=True, frozen=True)
class CustomPrimer:
    """A custom primer feature in the shape of a BED3+1 record."""

    refname: str
    start: int
    end: int
    primary_key: str

panel: list[CustomPrimer] = [
    CustomPrimer("chr1", 1, 4, "primer1"),
    CustomPrimer("chr1", 5, 9, "primer2"),
]

detector = OverlapDetector()
for primer in panel:
    detector.add(Interval(primer.chrom, primer.start, primer.end, name=primer.primary_key))

primer_lookup: dict[str, CustomPrimer] = {primer.primary_key: primer for primer in panel}
overlapping_intervals: list[Interval] = detector.get_overlaps(Interval("chr1", 2, 3))
overlapping_primers: list[CustomPrimer] = [primer_lookup[interval.name] for interval in overlapping_intervals]
```

What makes this challenging to use is:

1. The `OverlapDetector` only supports storing [`Interval`](https://github.com/fulcrumgenomics/pybedlite/blob/3a4b23a7fd8369edb810e90f4c19a5b763a0f561/pybedlite/overlap_detector.py#L129) objects
2. The `OverlapDetector` can only be queried with [`Interval`](https://github.com/fulcrumgenomics/pybedlite/blob/3a4b23a7fd8369edb810e90f4c19a5b763a0f561/pybedlite/overlap_detector.py#L129) objects
4. This library's primary data structure [`BedRecord`](https://github.com/fulcrumgenomics/pybedlite/blob/3a4b23a7fd8369edb810e90f4c19a5b763a0f561/pybedlite/bed_record.py#L47) doesn't work with `OverlapDetector`
    - Often requires the user to call a [`to_interval()`](https://github.com/fulcrumgenomics/pybedlite/blob/3a4b23a7fd8369edb810e90f4c19a5b763a0f561/pybedlite/bed_record.py#L206-L228) converter
    - Often requires the user to call a [`from_bedrecord()`](https://github.com/fulcrumgenomics/pybedlite/blob/3a4b23a7fd8369edb810e90f4c19a5b763a0f561/pybedlite/overlap_detector.py#L105-L126) converter
5. In order to convert back to your data of interest, you must knowingly store a primary key in the `name` field of `Interval` and perform a dictionary lookup (as shown above). If you don't have a primary key, you will need to make one.
6. Any intervals must be added separately from class instantiation, often adding 2 LOC.

## Example with this PR

```python
@dataclass(eq=True, frozen=True)
class CustomPrimer:
    """A custom primer feature in the shape of a BED3+1 record."""

    refname: str
    start: int
    end: int
    primary_key: str

panel: list[CustomPrimer] = [
    CustomPrimer("chr1", 1, 4, "primer1"),
    CustomPrimer("chr1", 5, 9, "primer2"),
]

detector: OverlapDetector[CustomPrimer] = OverlapDetector(panel)
overlapping_primers: list[CustomPrimer] = detector.get_overlaps(Interval("chr1", 2, 3))
```

*NB: although we are using an `Interval` to query the OverlapDetector, the type system is aware that we built the OverlapDetector with `CustomPrimer` types and all overlap functions will always return `CustomPrimer` objects. A user could alternatively query the overlap detector with any other interval-like feature but still receive `CustomerPrimer` objects which overlap.*

*NB: the BED spec notation BED3+1 is described [here](https://github.com/samtools/hts-specs/blob/master/BEDv1.pdf)*