### PR TITLE
ci: update wheels to build aarch64/arm versions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: 3.9
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.15.0
+        run: python -m pip install cibuildwheel==2.23.1
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,8 +1,8 @@
 name: Build wheels for multiple platforms
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,10 +25,10 @@ jobs:
           - os: ubuntu-24.04-arm
             target: musllinux
             arch: aarch64
-          - os: macos-latest
+          - os: macos-13
             target: macosx
             arch: x86_64
-          - os: macos-latest
+          - os: macos-15
             target: macosx
             arch: arm64
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,6 +54,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: pybedlite-${{ matrix.python }}-${{ matrix.platform.target }}_${{ matrix.platform.arch }}
           path: ./wheelhouse/*.whl
           if-no-files-found: error

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,15 +19,12 @@ jobs:
           - os: ubuntu-24.04
             target: musllinux
             arch: x86_64
-          # These don't work right now - they just hang while pulling the build image from quay.
-          # If this doesn't resolve itself, we could try to configure different images:
-          # https://cibuildwheel.readthedocs.io/en/stable/options/.
-          #- os: ubuntu-24.04
-          #  target: manylinux
-          #  arch: aarch64
-          #- os: ubuntu-24.04
-          #  target: musllinux
-          #  arch: aarch64
+          - os: ubuntu-24.04-arm
+            target: manylinux
+            arch: aarch64
+          - os: ubuntu-24.04-arm
+            target: musllinux
+            arch: aarch64
           - os: macos-latest
             target: macosx
             arch: x86_64

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,6 +54,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: pybedlite-${{ matrix.python }}-${{ matrix.platform.target }}_${{ matrix.platform.arch }}
+          name: pybedlite-${{ matrix.python }}-${{ matrix.platform.target }}_${{ matrix.platform.arch }}.whl
           path: ./wheelhouse/*.whl
           if-no-files-found: error


### PR DESCRIPTION
Also fixes the _name_ of the uploaded artifact.  It previously worked using `actions/upload-artifact@v3`, but it started failing with #41 which updated this action to `actions/upload-artifact@v4` (see: https://github.com/actions/upload-artifact/pull/501; in [v4 artifacts are immutable unless deleted, whereas in v3 they were mutable](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#overwriting-an-artifact)).

See manual wheels build: https://github.com/fulcrumgenomics/pybedlite/actions/runs/13880916896