### PR TITLE
chore(release): bump to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pybedlite"
-version = "1.0.1-dev"
+version = "1.1.0"
 description = "Lightweight Python interfaces for reading, writing, and querying genomic regions (BED)"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "pybedlite"
-version = "1.0.1.dev0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
Preparing for release. All commits between versions are here:

- https://github.com/fulcrumgenomics/pybedlite/compare/1.0.0...9381d438f45aa95355591e4284f15c3d0f55f42d?expand=1

Notable changes include:

1. Drop support for Py3.8
2. Add support for Py3.12 & Py3.13
3. Move from `cgranges` to `superintervals`
4. Updates to GitHub Actions, README, and other docs
5. Move from `poetry` to `uv` as the dev tool

Given this is a non API breaking update, I bumped to `1.1.0` from `1.0.0`.