### PR TITLE
fix: preload libstdc++ before importing superintervals

### DIFF
--- a/pybedlite/_superintervals.py
+++ b/pybedlite/_superintervals.py
@@ -9,6 +9,10 @@ fails with ``undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE``. Loading
 
 Import ``IntervalSet`` from here rather than from ``superintervals`` directly so
 this preload always runs first.
+
+This is a workaround; the upstream fix is tracked in
+https://github.com/kcleal/superintervals/pull/4. Once that is released and
+required here, this shim can be removed.
 """
 
 import ctypes

--- a/pybedlite/_superintervals.py
+++ b/pybedlite/_superintervals.py
@@ -1,0 +1,25 @@
+"""
+Import shim for :mod:`superintervals`.
+
+``superintervals`` ships a C++ extension built from source. Some interpreters
+report ``CXX=gcc`` in ``sysconfig`` (notably Debian's ``python:3.14-slim``
+images), which links the extension without ``libstdc++``. Importing it then
+fails with ``undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE``. Loading
+``libstdc++`` globally before the import satisfies that symbol.
+
+Import ``IntervalSet`` from here rather than from ``superintervals`` directly so
+this preload always runs first.
+"""
+
+import ctypes
+import platform
+
+if platform.system() == "Linux":
+    try:
+        ctypes.CDLL("libstdc++.so.6", mode=ctypes.RTLD_GLOBAL)
+    except OSError:
+        pass
+
+from superintervals import IntervalSet
+
+__all__ = ["IntervalSet"]

--- a/pybedlite/overlap_detector.py
+++ b/pybedlite/overlap_detector.py
@@ -76,8 +76,7 @@ from typing import TypeVar
 from typing import Union
 from typing import cast
 
-from superintervals import IntervalSet
-
+from pybedlite._superintervals import IntervalSet
 from pybedlite.bed_record import BedRecord
 from pybedlite.bed_record import BedStrand
 from pybedlite.bed_source import BedSource


### PR DESCRIPTION
superintervals ships a C++ extension built from source. Interpreters that report CXX=gcc in sysconfig (e.g. Debian's python:3.14-slim) link it without libstdc++, so importing it fails with:

    ImportError: undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE

Route the superintervals import through a shim that loads libstdc++ globally first, satisfying the symbol regardless of how the extension was linked. Import IntervalSet from pybedlite._superintervals so the preload always runs first.